### PR TITLE
fixed bug and added a countdown

### DIFF
--- a/classes/Fighter.js
+++ b/classes/Fighter.js
@@ -1,5 +1,5 @@
-import { gameOver } from "../engine/end-match.js";
 import { c, canvas, gravity } from "../index.js";
+import { gameOver } from "../src/helper.js";
 import { Sprite } from "./Sprite.js";
 
 export class Fighter extends Sprite {

--- a/classes/Game.js
+++ b/classes/Game.js
@@ -43,11 +43,9 @@ export class Game {
   startGame() {
     if (this.activePlayer.isReady && this.activeEnemy.isReady) {
       document.getElementById("readyBar").style.display = "none";
-      if (countdown === 0) {
         decreaseTimer();
         playerControls();
         this.toggleHitBoxVisualizers();
-      }
     }
   }
 

--- a/classes/Game.js
+++ b/classes/Game.js
@@ -1,11 +1,11 @@
 import { animate } from "../engine/animate.js";
 import { playerControls } from "../engine/player-controls.js";
-import { decreaseTimer } from "../src/utils.js";
+import { countdown, decreaseTimer } from "../src/utils.js";
 import { Fighter } from "./Fighter.js";
 import { Sprite } from "./Sprite.js";
 
 export class Game {
-  constructor({ setStage, setShop, player, enemy, skip }) {
+  constructor({ setStage, setShop, player, enemy, skip}) {
     this.stage = [new Sprite(setStage)];
     this.stageAccessories = [new Sprite(setShop)];
     this.player = [new Fighter(player)];
@@ -16,26 +16,8 @@ export class Game {
     this.activeEnemy = null;
     this.startBattle = false;
     this.skip = skip;
-    this.alreadyRan = false;
     this.showHitbox = true;
-    this.readyHandler = function (event) {
-      if (event.key === " " && !this.activePlayer.isReady) {
-        this.activePlayer.setReady();
-        console.log("wtf", this.activePlayer.isReady);
-        document.getElementById("readyPlayerOne").style.color = "lightgreen";
-      } else if (event.key === "ArrowDown" && !this.activeEnemy.isReady) {
-        this.activeEnemy.setReady();
-        console.log("wtf", this.activePlayer.isReady);
-        console.log("wtf", this.activeEnemy.isReady);
-        document.getElementById("readyEnemyOne").style.color = "lightgreen";
-      }
-      if (this.activeEnemy.isReady && this.activePlayer.isReady) {
-        this.startBattle = true;
-        this.beginBattle();
-        console.log("dog");
-        document.removeEventListener("keydown", this.readyCheckHandler, false);
-      }
-    };
+    this.beginBattle = false;
   }
   // export the active game configs to be used elsewhere
   activePlayer() {
@@ -51,12 +33,21 @@ export class Game {
     return this.activeAccessories;
   }
 
-  startGame() {
-    this.readyCheck();
+  skipCheck() {
+    animate();
+    decreaseTimer();
+    playerControls();
+    this.toggleHitBoxVisualizers();
+  }
 
-    if ((this.activePlayer.isReady && this.activeEnemy.isReady) || this.skip) {
-      animate();
-      this.toggleHitBoxVisualizers();
+  startGame() {
+    if (this.activePlayer.isReady && this.activeEnemy.isReady) {
+      document.getElementById("readyBar").style.display = "none";
+      if (countdown === 0) {
+        decreaseTimer();
+        playerControls();
+        this.toggleHitBoxVisualizers();
+      }
     }
   }
 
@@ -65,41 +56,6 @@ export class Game {
     this.activePlayer = this.generateRandomPlayer();
     this.activeEnemy = this.generateRandomEnemy();
     this.activeAccessories = this.generateRandomAccessories();
-  }
-
-  beginBattle() {
-    animate();
-    playerControls();
-    decreaseTimer();
-    document.getElementById("readyBar").remove();
-    window.removeEventListener("keydown", this.readyCheck);
-    console.log("a");
-    this.alreadyRan = true;
-  }
-
-  readyCheck() {
-    this.readyCheckHandler = this.readyHandler.bind(this);
-
-    if (this.alreadyRan) return;
-    if (this.skip) {
-      this.beginBattle();
-    } else {
-      document.addEventListener("keydown", this.readyCheckHandler, false);
-
-      console.log("bsss", !this.alreadyRan);
-      console.log("startBattle?", this.startBattle);
-      console.log("player1 ready?", this.activePlayer.isReady);
-      console.log("player2 ready?", this.activeEnemy.isReady);
-
-      if (
-        this.activePlayer.isReady === true &&
-        this.activeEnemy.isReady === true &&
-        !this.alreadyRan
-      ) {
-        this.beginBattle();
-      }
-      console.log("already ran?", this.alreadyRan);
-    }
   }
 
   toggleHitBoxVisualizers() {

--- a/engine/end-match.js
+++ b/engine/end-match.js
@@ -1,5 +1,0 @@
-export let gameOver = false
-
-export const toggleGameOver = () => {
-    gameOver = true;
-}

--- a/index.html
+++ b/index.html
@@ -15,12 +15,17 @@
 </head>
 <body>
   <!---large canvas div--->
-  <div style="position: relative; display: inline-block">
-    <div id="readyBar" class="anim">
-      <div id="readyPlayerOne">Ready?</div>
-      <div id="readyEnemyOne">Ready?</div>
-      <button id="startGame" onclick="">START</button>
+  
+</div>
+<div style="position: relative; display: inline-block">
+  <div id="readyBar" class="anim">
+    <div id="readyPlayerOne">Ready?</div>
+    <div id="readyEnemyOne">Ready?</div>
+    <button style="display: none;" id="startGame" onclick="">START</button>
+    <div id="notReady">
+      Players Not Ready
     </div>
+  </div>
     <!---smaller canvas div--->
     <div
       style="
@@ -111,8 +116,11 @@
         display: none;
       "
     >
+    <span>
       Tie
-    </div>
+    </span>
+  </div>
+  <button id="restart" style='display: none;' onclick="">RESTART</button>
     <canvas></canvas>
   </div>
 

--- a/index.js
+++ b/index.js
@@ -1,31 +1,28 @@
 import { nightBorne } from "./characters/nightBorne.js";
 import { sonSon } from "./characters/sonSon.js";
 import { Game } from "./classes/Game.js";
-import { Sprite } from "./classes/Sprite.js";
-import { setLoading, setShop, setStage } from "./stages/setStage.js";
+import { animate } from "./engine/animate.js";
+import { countDown, readyCheck, skipReadyCheck } from "./src/utils.js";
+import { setShop, setStage } from "./stages/setStage.js";
 
 // global variables
 export const canvas = document.querySelector("canvas");
 export const c = canvas.getContext("2d");
 export const gravity = 0.8;
 
-
-
-let game;
+export let game;
 export let player;
 export let enemy;
 export let background;
 export let shop;
+export let skipCheck = false;
 
 // set main loading stage
 canvas.width = 1024;
 canvas.height = 576;
-const loadingScreen = new Image()
-loadingScreen.src = './img/loading_screen.png'
 
-loadingScreen.onload = function(){
-    c.drawImage(loadingScreen, 0, 0)
-}
+const loadingScreen = new Image();
+loadingScreen.src = "./img/loading_screen.png";
 
 // set game configurations
 const gameConfigs = {
@@ -33,16 +30,45 @@ const gameConfigs = {
   setShop,
   player: nightBorne,
   enemy: sonSon,
-  skip: false,
+  skip: skipCheck,
 };
 
-// start the game
-document.querySelector("#startGame").addEventListener("click", (e) => {
+// load the game
+window.addEventListener("load", (e) => {
   game = new Game(gameConfigs);
   game.loadGame();
   player = game.activePlayer;
   enemy = game.activeEnemy;
   background = game.activeStage;
   shop = game.activeAccessories;
-  game.startGame();
+  c.drawImage(loadingScreen, 0, 0);
+  if(skipCheck) {
+    document.getElementById("readyBar").style.display = "none";
+    skipReadyCheck()
+  }
+});
+
+// readyCheck event listener
+window.addEventListener("keydown", (event) => {
+    if (game.activePlayer.isReady && game.activeEnemy.isReady) {
+      window.removeEventListener("keydown", readyCheck);
+    } else {
+      readyCheck(event, game.activePlayer, game.activeEnemy);
+    }
+});
+
+// start the game
+document.querySelector("#startGame").addEventListener("click", () => {
+  document.getElementById("readyBar").style.display = "none";
+  animate();
+  countDown();
+});
+
+// re-start the game
+
+// TODO: Right now it just refreshes the page. Want to make it eventually
+// make it add all of the stuff back instead of refreshing
+
+document.querySelector("#restart").addEventListener("click", (e) => {
+  window.location.reload();
 });

--- a/src/helper.js
+++ b/src/helper.js
@@ -3,3 +3,7 @@ export const lastKeyHelper = (arg) => {
   lastKey = arg;
 };
 
+export let gameOver = false;
+export const toggleGameOver = () => {
+  gameOver = true;
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
-import { toggleGameOver } from "../engine/end-match.js";
-import { player, enemy } from "../index.js";
+import { player, enemy, game } from "../index.js";
+import { toggleGameOver } from "./helper.js";
 
 export const rectangularCollision = ({ rectangle1, rectangle2, offset }) => {
 
@@ -17,6 +17,7 @@ export const rectangularCollision = ({ rectangle1, rectangle2, offset }) => {
 export const determineWinner = ({ player, enemy, timerId }) => {
   clearTimeout(timerId);
   document.querySelector("#displayText").style.display = "flex";
+  document.querySelector("#restart").style.display = "flex";
 
   if (player.health === enemy.health) {
     document.querySelector("#displayText").innerHTML = "Tie";
@@ -43,3 +44,46 @@ export const decreaseTimer = () => {
     determineWinner({ player, enemy, timerId });
   }
 };
+
+export let countdown = 4
+export const countDown = () => {
+  document.querySelector("#displayText").style.display = "flex";
+  if(countdown > 1) {
+    setTimeout(countDown, 1000)
+    countdown--;
+    document.querySelector("#displayText").innerHTML = `${countdown}!`;
+  } else if (countdown === 1){
+    setTimeout(countDown, 1000)
+    countdown--;
+    document.querySelector("#displayText").innerHTML = `FIGHT!`
+  } else if(countdown === 0) {
+    document.querySelector("#displayText").style.display = "none";
+    return game.startGame()
+  }
+}
+
+export const skipReadyCheck = () => {
+  return game.skipCheck()
+}
+
+export const readyCheck = (event, player, enemy) => {
+  if (event.key === " ") {
+    player.setReady();
+    document.getElementById("readyPlayerOne").style.color = "lightgreen";
+
+    } if (event.key === "ArrowDown") {
+      enemy.setReady();
+      document.getElementById("readyEnemyOne").style.color = "lightgreen";
+    }
+
+    if(!player.isReady && enemy.isReady) {
+      document.getElementById("notReady").textContent = "Player 1 is Not Ready";
+    }else  if(player.isReady && !enemy.isReady) {
+      document.getElementById("notReady").textContent = "Player 2 is Not Ready";
+    } else {      
+      document.getElementById("notReady").style.color = "lightgreen";
+      document.querySelector("#startGame").style.display = "flex";
+      document.getElementById("notReady").textContent = 'Press "Start" to Begin!';
+    }
+};
+

--- a/styles.css
+++ b/styles.css
@@ -27,3 +27,32 @@
   -webkit-text-stroke-width: 1px;
   -webkit-text-stroke-color: black;
 }
+
+#notReady {
+  border: 5px solid;
+  position: absolute;
+  top: 10%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 10px;
+  -webkit-text-fill-color: white;
+  -webkit-text-stroke-width: 1px;
+  -webkit-text-stroke-color: black;
+}
+
+#restart {
+  position: absolute;
+  bottom: 42%;
+  height: fit-content;
+  width: fit-content;
+  left: 45%;
+}
+
+#startGame {
+  position: absolute;
+  display: flex;
+  width: fit-content;
+  bottom: -30px;
+  right: 27rem;
+  font-size: 30px;
+}


### PR DESCRIPTION
**Changes to Fix Bug** 
- fixed the starting game bug by moving `readyCheck` into `utils.js`
- `readyCheck()` is run by an eventlistener on the homepage
- if the `player` and `enemy` are ready then the readyCheck event listener is removed

**Misc. Changes**
- added an `onload eventlistener` that loads everything the game needs and checks if the readycheck is skipped.
      - added `skipCheck()` to `Game.js`, skipCheck just runs the game, no ready check needed
- added a `countDown()` to `utils.js`
    - `countDown()` displays a countdown on screen followed by `Fight!` after a few seconds  
    - also starts the game after the `countdown` hits 0
    - the onClick for startGame on `index.js` now runs `countDown()` instead of `game.startGame()`
- Moved `toggleGameOver` and `gameOver` to the `helpers.js` file
- Added text to the loading screen that lets you know which players are ready
    - when both players are ready the `start` button pops up
- added a `restart` button. It refreshes the page
